### PR TITLE
Expand allowed Newtonsoft versions

### DIFF
--- a/src/MockHttpClient/MockHttpClient.csproj
+++ b/src/MockHttpClient/MockHttpClient.csproj
@@ -25,7 +25,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="[9.0.1,12)" />
     <PackageReference Include="System.Xml.XmlSerializer" Version="4.3.0" />
   </ItemGroup>
 

--- a/src/MockHttpClient/MockHttpClient.csproj
+++ b/src/MockHttpClient/MockHttpClient.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.4;net462</TargetFrameworks>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
-    <Version>1.0.0</Version>
+    <Version>1.0.1</Version>
     <Authors>Alex Davies</Authors>
     <Company>Codecutout</Company>
     <Description>Easily mock HttpClient with canned responses to make testing easier</Description>

--- a/src/MockHttpClient/MockHttpClient.csproj
+++ b/src/MockHttpClient/MockHttpClient.csproj
@@ -10,22 +10,16 @@
     <PackageLicenseUrl>https://github.com/codecutout/MockHttpClient/blob/master/LICENSE</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/codecutout/MockHttpClient</PackageProjectUrl>
     <PackageTags>MockHttpClient Mock Fake HttpClient HttpMessageHandler</PackageTags>
-    <AssemblyVersion>1.0.0.0</AssemblyVersion>
-    <FileVersion>1.0.0.0</FileVersion>
+    <AssemblyVersion>1.0.1.0</AssemblyVersion>
+    <FileVersion>1.0.1.0</FileVersion>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|netstandard1.4|AnyCPU'">
-    <NoWarn />
-    <WarningLevel>4</WarningLevel>
-    <DocumentationFile>bin\Debug\netstandard1.4\MockHttpClient.xml</DocumentationFile>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|netstandard1.4|AnyCPU'">
-    <DocumentationFile>bin\Release\netstandard1.4\MockHttpClient.xml</DocumentationFile>
+  <PropertyGroup>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="[9.0.1,12)" />
+    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
     <PackageReference Include="System.Xml.XmlSerializer" Version="4.3.0" />
   </ItemGroup>
 


### PR DESCRIPTION
MockHttpClient can support more than just Newtonsoft 10.X. For better compatiblity, I expanded it to versions 9,10, and 11.